### PR TITLE
feat(idempotent): AOP를 이용하여 like post 메서드가 멱등성을 보장하도록 구현

### DIFF
--- a/src/main/java/mayfifth99/twitter/common/idempotency/Idempotency.java
+++ b/src/main/java/mayfifth99/twitter/common/idempotency/Idempotency.java
@@ -1,0 +1,13 @@
+package mayfifth99.twitter.common.idempotency;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import mayfifth99.twitter.common.ui.Response;
+
+@Getter
+@AllArgsConstructor
+public class Idempotency {
+
+    private final String key;
+    private final Response<?> response;
+}

--- a/src/main/java/mayfifth99/twitter/common/idempotency/IdempotencyAspect.java
+++ b/src/main/java/mayfifth99/twitter/common/idempotency/IdempotencyAspect.java
@@ -1,0 +1,37 @@
+package mayfifth99.twitter.common.idempotency;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import mayfifth99.twitter.common.ui.Response;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class IdempotencyAspect {
+
+    private final IdempotencyRepository idempotencyRepository;
+    private final HttpServletRequest request;
+
+    @Around("@annotation(Idempotent)")
+    public Object checkIdempotency(ProceedingJoinPoint jointPoint) throws Throwable {
+        String idempotencyKey = request.getHeader("Idempotency-Key");
+        if(idempotencyKey == null){
+            return jointPoint.proceed();
+        }
+
+        Idempotency idempotency = idempotencyRepository.getByKey(idempotencyKey);
+        if(idempotency != null){
+            return idempotency.getResponse(); // 로직을 수행하지 않고 응답 반환
+        }
+
+        Object result = jointPoint.proceed(); // 대상 메서드(@Idempontent) 실행
+        Idempotency newIdempotency = new Idempotency(idempotencyKey, (Response<?>) result);
+        idempotencyRepository.save(newIdempotency);
+
+        return result;
+    }
+}

--- a/src/main/java/mayfifth99/twitter/common/idempotency/IdempotencyRepository.java
+++ b/src/main/java/mayfifth99/twitter/common/idempotency/IdempotencyRepository.java
@@ -1,0 +1,7 @@
+package mayfifth99.twitter.common.idempotency;
+
+public interface IdempotencyRepository {
+
+    Idempotency getByKey(String key);
+    void save(Idempotency idempotency);
+}

--- a/src/main/java/mayfifth99/twitter/common/idempotency/Idempotent.java
+++ b/src/main/java/mayfifth99/twitter/common/idempotency/Idempotent.java
@@ -1,0 +1,12 @@
+package mayfifth99.twitter.common.idempotency;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Idempotent {
+
+}

--- a/src/main/java/mayfifth99/twitter/common/idempotency/repository/IdempotencyRepositoryImpl.java
+++ b/src/main/java/mayfifth99/twitter/common/idempotency/repository/IdempotencyRepositoryImpl.java
@@ -1,0 +1,29 @@
+package mayfifth99.twitter.common.idempotency.repository;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import mayfifth99.twitter.common.idempotency.Idempotency;
+import mayfifth99.twitter.common.idempotency.IdempotencyRepository;
+import mayfifth99.twitter.common.idempotency.repository.entity.IdempotencyEntity;
+import mayfifth99.twitter.common.idempotency.repository.jpa.JpaIdempotencyRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class IdempotencyRepositoryImpl implements IdempotencyRepository {
+
+    private final JpaIdempotencyRepository jpaIdempotencyRepository;
+
+    @Override
+    public Idempotency getByKey(String key) {
+        Optional<IdempotencyEntity> idempotencyEntity = jpaIdempotencyRepository.findByIdempotencyKey(
+                key);
+
+        return idempotencyEntity.map(IdempotencyEntity::toIdempotency).orElse(null);
+    }
+
+    @Override
+    public void save(Idempotency idempotency) {
+        jpaIdempotencyRepository.save(new IdempotencyEntity(idempotency));
+    }
+}

--- a/src/main/java/mayfifth99/twitter/common/idempotency/repository/entity/IdempotencyEntity.java
+++ b/src/main/java/mayfifth99/twitter/common/idempotency/repository/entity/IdempotencyEntity.java
@@ -1,0 +1,44 @@
+package mayfifth99.twitter.common.idempotency.repository.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import mayfifth99.twitter.common.idempotency.Idempotency;
+import mayfifth99.twitter.common.utils.ResponseObjectMapper;
+
+@Entity
+@Table(name = "community_idempontency")
+@NoArgsConstructor
+@AllArgsConstructor
+public class IdempotencyEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true, nullable = false)
+    private String idempotencyKey;
+
+    @Getter
+    @Column(nullable = false)
+    private String response;
+
+    public IdempotencyEntity(Idempotency idempotency){
+        this.idempotencyKey = idempotency.getKey();
+        this.response = ResponseObjectMapper.toStringResponse(idempotency.getResponse());
+    }
+
+    public Idempotency toIdempotency(){
+        return new Idempotency(this.idempotencyKey,
+                ResponseObjectMapper.toResponseObject(response));
+    }
+
+
+
+}

--- a/src/main/java/mayfifth99/twitter/common/idempotency/repository/jpa/JpaIdempotencyRepository.java
+++ b/src/main/java/mayfifth99/twitter/common/idempotency/repository/jpa/JpaIdempotencyRepository.java
@@ -1,0 +1,10 @@
+package mayfifth99.twitter.common.idempotency.repository.jpa;
+
+import java.util.Optional;
+import mayfifth99.twitter.common.idempotency.repository.entity.IdempotencyEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaIdempotencyRepository extends JpaRepository<IdempotencyEntity, Long> {
+
+    Optional<IdempotencyEntity> findByIdempotencyKey(String key);
+}

--- a/src/main/java/mayfifth99/twitter/common/utils/ResponseObjectMapper.java
+++ b/src/main/java/mayfifth99/twitter/common/utils/ResponseObjectMapper.java
@@ -1,0 +1,30 @@
+package mayfifth99.twitter.common.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import mayfifth99.twitter.common.ui.Response;
+
+public class ResponseObjectMapper {
+
+    private ResponseObjectMapper() {
+    }
+
+    private static final ObjectMapper objMapper = new ObjectMapper();
+
+    public static Response toResponseObject(String response) {
+        try {
+            return objMapper.readValue(response, Response.class);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public static String toStringResponse(Response<?> response) {
+        try{
+            return objMapper.writeValueAsString(response);
+        }catch (Exception e){
+            return null;
+        }
+    }
+
+    ;
+}

--- a/src/main/java/mayfifth99/twitter/post/ui/controller/PostController.java
+++ b/src/main/java/mayfifth99/twitter/post/ui/controller/PostController.java
@@ -1,6 +1,7 @@
 package mayfifth99.twitter.post.ui.controller;
 
 import lombok.RequiredArgsConstructor;
+import mayfifth99.twitter.common.idempotency.Idempotent;
 import mayfifth99.twitter.common.ui.Response;
 import mayfifth99.twitter.post.application.PostService;
 import mayfifth99.twitter.post.application.dto.CreatePostRequestDto;
@@ -31,6 +32,7 @@ public class PostController {
         return Response.ok(null);
     }
 
+    @Idempotent
     @PostMapping("/{postId}/like")
     public Response<Void> likePost(@PathVariable Long postId, @RequestBody LikeRequestDto dto){
         postService.likePost(postId, dto);


### PR DESCRIPTION
TODO
다른 Post, Patch 메서드에도 동일한 로직을 적용해서 멱등성 보장 로직 구현 필요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the way post interactions are processed. When you like a post, repeated actions are now handled more gracefully to ensure you receive a consistent response. This update helps streamline user interactions so that accidental duplicate actions do not create unexpected outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->